### PR TITLE
revert to fastapi and update version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,9 @@
 
+## 0.0.5 (2024-08-28)
+
+* switch back to `fastapi` (instead of fastapi-slim) and set version to `>=0.100.0`
+* add `pydantic>=2.0` requirement
+
 ## 0.0.4 (2024-08-22)
 
 * switch to `pyproject.toml` for python project metadata

--- a/fastapi_authorization_gateway/types.py
+++ b/fastapi_authorization_gateway/types.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import Annotated
 
 from fastapi import Request
@@ -38,8 +38,9 @@ class RoutePermission(BaseModel):
     path_params: Optional[Mapping[str, Annotated[Any, Path]]] = None
     query_params: Optional[Mapping[str, Annotated[Any, Query]]] = None
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
 
 
 class RequestTransformation(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,9 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "fastapi-slim>=0.111.0",
-    "typing_extensions; python_version < '3.9'",
+    "fastapi>=0.100.0",
+    "pydantic>=2.0",
+    "typing_extensions",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
FastAPI reverted their changed and now doesn't include useless dependencies https://github.com/fastapi/fastapi/discussions/11525

we can move back to fastapi instead of fastapi-slim and also relaxe the version dependency!